### PR TITLE
feat: ikke farg loggene

### DIFF
--- a/.nais/vars.yaml
+++ b/.nais/vars.yaml
@@ -13,8 +13,8 @@ envs:
     value: "5432"
   - name: JAVA_TIMEZONE
     value: UTC+1
-  - name: MB_EMOJI_IN_LOGS
-    value: "true"
+  - name: MB_COLORIZE_LOGS
+    value: "false"
   - name: MB_PLUGINS_DIR
     value: "/tmp"
   - name: MB_ADMIN_EMAIL


### PR DESCRIPTION
Shellet mitt er ikke så happy for farger i loggene, så det blir støy når jeg skal feilsøke.

Emoji i logger er default på.